### PR TITLE
Retornar lista de usuários cadastrados e usuários por id

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { CommentModule } from './modules/comment/comment.module';
 import { HabitModule } from './modules/habit/habit.module';
 import { RewardModule } from './modules/reward/reward.module';
 import { VoteModule } from './modules/vote/vote.module';
+import { UserController } from './modules/user/user.controller';
 
 @Module({
   imports: [
@@ -26,7 +27,7 @@ import { VoteModule } from './modules/vote/vote.module';
     RewardModule,
     VoteModule,
   ],
-  controllers: [AppController, AuthController],
+  controllers: [AppController, AuthController, UserController],
   providers: [AppService, AuthService],
 })
 export class AppModule {

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,0 +1,28 @@
+import {
+    Controller,
+    Get,
+    UseInterceptors,
+} from '@nestjs/common';
+
+import { UserService } from '../user/user.service';
+import { ApiUseTags } from '@nestjs/swagger';
+import { ResponseTransformInterceptor } from '@kl/common/pipes/interceptors/response.pipe';
+
+@Controller('user')
+@ApiUseTags('user')
+@UseInterceptors(ResponseTransformInterceptor)
+export class UserController {
+    constructor(
+        private userService: UserService,
+    ) { }
+
+    @Get('getAllUsers')
+    async getUsers() {
+        const users = await this.userService.getUsers();
+        // console.log("users = ", users);
+        return {
+            message: 'Usuários recuperados com sucesso!',
+            data: users
+        };
+    }
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -31,7 +31,7 @@ export class UserController {
     @Get('/:email')
     async getUserByEmail(@Param('email') email) {
         const user = await this.userService.getUserByEmail(email);
-        console.log(email)
+
         return {
             message: 'Usuário recuperado com sucesso!',
             data: user

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -2,11 +2,14 @@ import {
     Controller,
     Get,
     UseInterceptors,
+    Body,
+    Param,
 } from '@nestjs/common';
 
 import { UserService } from '../user/user.service';
 import { ApiUseTags } from '@nestjs/swagger';
 import { ResponseTransformInterceptor } from '@kl/common/pipes/interceptors/response.pipe';
+import { UserDTO } from './dto/user.dto';
 
 @Controller('user')
 @ApiUseTags('user')
@@ -16,13 +19,22 @@ export class UserController {
         private userService: UserService,
     ) { }
 
-    @Get('getAllUsers')
+    @Get('users')
     async getUsers() {
         const users = await this.userService.getUsers();
-        // console.log("users = ", users);
         return {
             message: 'Usuários recuperados com sucesso!',
             data: users
+        };
+    }
+
+    @Get('users/:email')
+    async getUserByEmail(@Param('email') email) {
+        const user = await this.userService.getUserByEmail(email);
+        console.log(email)
+        return {
+            message: 'Usuário recuperado com sucesso!',
+            data: user
         };
     }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -11,8 +11,8 @@ import { ApiUseTags } from '@nestjs/swagger';
 import { ResponseTransformInterceptor } from '@kl/common/pipes/interceptors/response.pipe';
 import { UserDTO } from './dto/user.dto';
 
-@Controller('user')
-@ApiUseTags('user')
+@Controller('users')
+@ApiUseTags('users')
 @UseInterceptors(ResponseTransformInterceptor)
 export class UserController {
     constructor(

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -19,7 +19,7 @@ export class UserController {
         private userService: UserService,
     ) { }
 
-    @Get('users')
+    @Get('/')
     async getUsers() {
         const users = await this.userService.getUsers();
         return {
@@ -28,7 +28,7 @@ export class UserController {
         };
     }
 
-    @Get('users/:email')
+    @Get('/:email')
     async getUserByEmail(@Param('email') email) {
         const user = await this.userService.getUserByEmail(email);
         console.log(email)


### PR DESCRIPTION
Neste PR os seguintes endpoints foram adicionados:
* `/user` - Retorna todos os usuários cadastrados no sistema
* `/user/{email}` - Retorna o usuário associado a um endereço de e-mail